### PR TITLE
[bn] Use IPA symbols for post-alveolar affricates

### DIFF
--- a/bn/phonemes.txt
+++ b/bn/phonemes.txt
@@ -14,10 +14,10 @@ kh	kʰ
 g	ɡ
 gh	ɡʰ
 N	ŋ
-c	c
-ch	cʰ
-j	ɟ
-jh	ɟʰ
+c	t͡ʃ
+ch	t͡ʃʰ
+j	d͡ʒ
+jh	d͡ʒʰ
 T	ʈ
 Th	ʈʰ
 D	ɖ


### PR DESCRIPTION
Before this change, the mapping used the symbols /c/ and /ɟ/,
which (according to the official IPA chart) are palatal stops;
whereas Bangla pronunciation uses post-alveolar affricates.