### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/docker-images/festival/Dockerfile
+++ b/docker-images/festival/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM langtech/base-language-resources:v1_1
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
       automake \
       bc \
       curl \

--- a/docker-images/language-resources/Dockerfile
+++ b/docker-images/language-resources/Dockerfile
@@ -19,7 +19,7 @@ ENV NODEJS_VERSION="v8.9.3"
 ENV BAZEL_VERSION="0.8.0"
 ENV ANDROID_TOOLS_VERSION="3859397"
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
       sox \
       curl \
       libicu-dev \

--- a/docker-images/merlin/Dockerfile
+++ b/docker-images/merlin/Dockerfile
@@ -17,7 +17,7 @@ FROM langtech/base-festival:v1_1
 # Required by run_merlin.py
 ENV USER root
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
   autoconf \
   build-essential \
   ca-certificates \

--- a/mul_034/script_util.py
+++ b/mul_034/script_util.py
@@ -19,7 +19,7 @@ import sys
 
 # Non-hermetic dependency on PyICU. Install this in one of several ways:
 # * pip install PyICU
-# * apt-get install python-pyicu python3-icu
+# * apt-get --no-install-recommends install -y python-pyicu python3-icu
 import icu
 
 from utils import utf8

--- a/my/binom_test.py
+++ b/my/binom_test.py
@@ -31,7 +31,7 @@ from __future__ import division, print_function
 
 import sys
 
-from scipy import stats  # Debian/Ubuntu: apt-get install python-scipy
+from scipy import stats  # Debian/Ubuntu: apt-get --no-install-recommends install -y python-scipy
 
 
 def UpperTailPValue(successes, trials, prob):

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -12,7 +12,7 @@ else
   ## Fix this when Xenial becomes available.
   # sudo add-apt-repository ppa:suawekk/trusty-backports -y
   # sudo apt-get update -qq
-  sudo apt-get install -q -y libicu-dev
+  sudo apt-get --no-install-recommends install -y -q libicu-dev
 fi
 
 curl -L "https://github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-installer-${MY_OS}-x86_64.sh" > bazel-installer.sh

--- a/utils/icu_util.py
+++ b/utils/icu_util.py
@@ -21,7 +21,7 @@ import sys
 
 # Non-hermetic dependency on PyICU. Install this in one of several ways:
 # * pip install PyICU
-# * apt-get install python-pyicu python3-icu
+# * apt-get --no-install-recommends install -y python-pyicu python3-icu
 import icu
 
 from utils import utf8


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>