### PR TITLE
Travis CI: Bump OS/SDK/tools versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: bionic
 language: python
 
 branches:
@@ -10,62 +10,28 @@ branches:
 
 env:
   global:
-    - ANDROID_SDK=4333796
-    - BAZEL=0.22.0
-    - JAVA_OPTS='-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee'
+    - ANDROID_SDK=6858069
+    - BAZEL=3.7.2
 
 matrix:
   fast_finish: true
   include:
     - os: linux
-      python: 2.7
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - MATRIX_EVAL="export CC=gcc-7 CXX=g++-7"
-    - os: linux
-      python: 3.3
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - MATRIX_EVAL="export CC=gcc-7 CXX=g++-7"
-    - os: linux
       python: 3.6
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - MATRIX_EVAL="export CC=gcc-7 CXX=g++-7"
     - os: osx
+      osx_image: xcode11.3
       language: cpp
-      env:
-        - PY=/usr/bin/python2.7
-        - MATRIX_EVAL=""
   allow_failures:
     - os: osx
+      osx_image: xcode11.3
       language: cpp
-      env:
-        - PY=/usr/bin/python2.7
-        - MATRIX_EVAL=""
 
 before_install:
-  - eval "${MATRIX_EVAL}"
   - . travis/before_install.sh
 
 install:
-  - yes | "$ANDROID_HOME/tools/bin/sdkmanager" 'build-tools;28.0.2' 'platforms;android-28' > /dev/null
-  - pip install -r travis/requirements.txt
+  - yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" 'build-tools;28.0.3' 'platforms;android-28' > /dev/null
+  - pip3 install -r travis/requirements.txt
 
 script:
   - travis/script.sh

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -1,13 +1,19 @@
 if [ "$TRAVIS_OS_NAME" = osx -o "$(uname)" = Darwin ]; then
   MY_OS=darwin
-  echo '$ python --version'
-  python --version
-  echo '$ pip --version'
-  pip --version
+  ANDROID_HOST_OS=mac
+  echo '$ python3 --version'
+  python3 --version
+  echo '$ pip3 --version'
+  pip3 --version
   # brew update
   brew bundle --file=travis/Brewfile
+  eval $(brew shellenv)
+  icu4c="${HOMEBREW_PREFIX}/opt/icu4c"
+  export PATH="${icu4c}/bin:${PATH}"
+  export PKG_CONFIG_PATH="${icu4c}/lib/pkgconfig:${PKG_COCNFIG_PATH}"
 else
   MY_OS=linux
+  ANDROID_HOST_OS=linux
   ## Optionally configure Trusty backports for a less ancient ICU.
   ## Fix this when Xenial becomes available.
   # sudo add-apt-repository ppa:suawekk/trusty-backports -y
@@ -17,15 +23,22 @@ fi
 
 curl -L "https://github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-installer-${MY_OS}-x86_64.sh" > bazel-installer.sh
 bash bazel-installer.sh --user
-export JAVA_HOME="$(bazel info java-home)"
-echo '$ $JAVA_HOME/bin/java -version'
-"$JAVA_HOME/bin/java" -version
+
+if [ -d "$JAVA_HOME" ]; then
+  echo JAVA_HOME="$JAVA_HOME"
+  echo '$ $JAVA_HOME/bin/java -version'
+  "$JAVA_HOME/bin/java" -version
+else
+  echo '$ java -version'
+  java -version
+fi
 
 if [ -z "$ANDROID_HOME" ]; then
   export ANDROID_HOME="$HOME/Android/Sdk"
-  mkdir -p "$ANDROID_HOME"
-  curl "https://dl.google.com/android/repository/sdk-tools-${MY_OS}-${ANDROID_SDK}.zip" > sdk-tools.zip
-  unzip -q sdk-tools.zip -d "$ANDROID_HOME"
+  mkdir -p "$ANDROID_HOME/cmdline-tools"
+  curl -L "https://dl.google.com/android/repository/commandlinetools-${ANDROID_HOST_OS}-${ANDROID_SDK}_latest.zip" > cmdline-tools.zip
+  unzip -q cmdline-tools.zip
+  mv cmdline-tools "$ANDROID_HOME/cmdline-tools/latest"
 fi
 
 echo ANDROID_HOME="$ANDROID_HOME"


### PR DESCRIPTION
This fixes the continuous build.

Upgrade the Linux version to Ubuntu 18.04 ("Bionic") and the macOS version to 10.14.6 ("Mojave"). Use the default version of Python 3, since Python 2.7 is EOL. Use the default version of Java, which is >= 11 everywhere. This means we can use the latest Android SDK tools (which had caused issues around 9a7c2c6 and Java 8). Upgrade Bazel to the latest 3.x.y release; Bazel 4.0.0 currently doesn't work with Xcode clang on macOS. Builds are green for me.